### PR TITLE
ci: skip build-and-push-image job if the dockerfile does not exist instead of failing the pipeline

### DIFF
--- a/.github/workflows/deploy-ghcr.yaml
+++ b/.github/workflows/deploy-ghcr.yaml
@@ -21,17 +21,22 @@ jobs:
       matrix:
         packages: ${{ fromJson(inputs.packages_deployment) }}
 
+    outputs:
+      DOCKERFILE_EXISTS: ${{ steps.check-dockerfile.outputs.DOCKERFILE_EXISTS }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Check if Dockerfile exists
+        id: check-dockerfile
         run: |
           if [ ! -f apps/${{ matrix.packages.name }}/Dockerfile ]; then
             echo "Dockerfile does not exist"
-            exit 1
+            echo "DOCKERFILE_EXISTS=false" >> $GITHUB_OUTPUT
           else
             echo "Dockerfile exists"
+            echo "DOCKERFILE_EXISTS=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Login ghcr.io
@@ -43,6 +48,7 @@ jobs:
           logout: true
 
       - name: Build and Push to ghcr
+        if: steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true'
         uses: docker/build-push-action@v3.2.0
         with:
           context: .

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - khing/test
 
 permissions:
     actions: read

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-            - khing/test
 
 permissions:
     actions: read


### PR DESCRIPTION
Example: https://github.com/stamford-syntax-club/course-compose/actions/runs/7369854546

Note the time it takes to finish each job (Currently there are only 2 services with a dockerfile)
![image](https://github.com/stamford-syntax-club/course-compose/assets/92321280/6a715e8c-ec0f-4a86-898f-3a2ccbbd690a)
