### PR TITLE
feat: endpoint caching for get course api

### DIFF
--- a/apps/course-api/.env.example
+++ b/apps/course-api/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=database_url_here
+REDIS_URL=redis_url_here

--- a/apps/course-api/.gitignore
+++ b/apps/course-api/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .env*
+!.env.example
 dist
 .prisma

--- a/apps/course-api/package.json
+++ b/apps/course-api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npx tsc",
     "start": "node dist/src/index.js",
-    "dev": "concurrently \"npx tsc --watch\" \"nodemon -q dist/src/index.js\"",
+    "dev": "pnpm exec dotenv -e .env.development -- concurrently \"npx tsc --watch\" \"nodemon -q dist/src/index.js\"",
     "integration": "docker compose -f docker-compose.integration.yaml down -v && docker compose -f docker-compose.integration.yaml up --build --force-recreate --abort-on-container-exit --exit-code-from app",
     "integration:jest": "jest test/integration --detectOpenHandles",
     "docker:test_build": "docker compose -f docker-compose.test-build.yaml down -v && docker compose -f docker-compose.test-build.yaml up -d --build --force-recreate",
@@ -27,7 +27,8 @@
     "module-alias": "^2.2.3",
     "mongodb": "^6.3.0",
     "mongoose": "^8.0.3",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "redis": "^4.6.12"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
@@ -52,6 +53,7 @@
     "@models": "dist/src/models",
     "@routes": "dist/src/routes",
     "@utils": "dist/src/utils",
+    "@middlewares": "dist/src/middlewares",
     "@root": "."
   }
 }

--- a/apps/course-api/src/app.ts
+++ b/apps/course-api/src/app.ts
@@ -3,11 +3,13 @@ import cors from "cors";
 import prismaClient from "@utils/prisma_utils";
 import courseRouter from "@routes/courses.route";
 import morgan from "morgan";
+import cacheEndpoint from "@middlewares/caching";
 
 const app = express();
 
 app.use(cors());
 app.use(morgan("combined"));
+app.use(cacheEndpoint);
 
 app.get("/", (req: Request, res: Response) => {
 	res.send("Welcome to Express & TypeScript Server");

--- a/apps/course-api/src/controllers/courses.controller.ts
+++ b/apps/course-api/src/controllers/courses.controller.ts
@@ -1,8 +1,10 @@
 import { Request, Response } from "express";
 import { paginate } from "@utils/pagination";
 import { getAllCourses, getCourseByCode } from "./get-courses";
+import { getRedisClient } from "@utils/redis_utils";
 
-// TODO: some caching here
+const cacheTTL = 60 * 60 * 7; // cache will expire after 1 week
+
 const handleGetAllCourses = async (req: Request, res: Response) => {
 	const pageSize = parseInt(req.query.pageSize as string) ? parseInt(req.query.pageSize as string) : 10;
 	const pageNumber = parseInt(req.query.pageNumber as string) ? parseInt(req.query.pageNumber as string) : 1;
@@ -17,6 +19,11 @@ const handleGetAllCourses = async (req: Request, res: Response) => {
 	try {
 		const { courses, count } = await getAllCourses(search, pageSize, pageNumber);
 		const data = paginate(courses, pageSize, pageNumber, count);
+
+		// fire and forget
+		const redisClient = await getRedisClient();
+		redisClient?.setEx(req.originalUrl, cacheTTL, JSON.stringify(data));
+
 		res.status(200).json(data);
 	} catch (error) {
 		console.log("Error: ", error);
@@ -36,6 +43,10 @@ const handleGetCourseByCode = async (req: Request, res: Response) => {
 				message: "Course not found"
 			});
 		}
+
+		const redisClient = await getRedisClient();
+		redisClient?.setEx(req.originalUrl, cacheTTL, JSON.stringify(course));
+
 		res.status(200).json(course);
 	} catch (error) {
 		console.log("Error: ", error);

--- a/apps/course-api/src/index.ts
+++ b/apps/course-api/src/index.ts
@@ -1,11 +1,9 @@
 import "module-alias/register";
-import dotenv from "dotenv";
+import "dotenv/config";
 import app from "./app";
-
-dotenv.config();
 
 const port = process.env.PORT || 8002;
 
 app.listen(port, () => {
-  console.log(`Server is 🔥 at http://localhost:${port}`);
+	console.log(`Server is 🔥 at http://localhost:${port}`);
 });

--- a/apps/course-api/src/middlewares/caching.ts
+++ b/apps/course-api/src/middlewares/caching.ts
@@ -1,0 +1,21 @@
+import { NextFunction, Request, Response } from "express";
+import { getRedisClient } from "@utils/redis_utils";
+
+export default async function cacheEndpoint(req: Request, res: Response, next: NextFunction) {
+	const endpoint = `${req.method} - ${req.originalUrl}`;
+
+	if (req.method !== "GET") {
+		console.log(`skipping cache middleware for unsupported method ${endpoint}`);
+		return next();
+	}
+
+	const redisClient = await getRedisClient();
+	const cachedResponse = await redisClient?.get(req.originalUrl);
+	if (!cachedResponse) {
+		console.log(`cache miss for endpoint: ${endpoint}, attempting to retrieve from database`);
+		return next();
+	}
+
+	console.log(`cache hit for endpoint: ${endpoint}, returning cached data`);
+	res.status(200).json(JSON.parse(cachedResponse));
+}

--- a/apps/course-api/src/utils/redis_utils.ts
+++ b/apps/course-api/src/utils/redis_utils.ts
@@ -1,0 +1,26 @@
+import { createClient } from "redis";
+
+const redisClient = createClient({
+	url: process.env.REDIS_URL
+});
+
+process.on("exit", async () => {
+	console.log("exiting redis..");
+	await redisClient.disconnect();
+	console.log("redis exited");
+});
+
+export async function getRedisClient() {
+	if (redisClient.isReady && redisClient.isOpen) {
+		return redisClient;
+	}
+
+	try {
+		await redisClient.connect();
+		return redisClient;
+	} catch (error) {
+		console.log("error connecting to redis:", error);
+		await redisClient.disconnect();
+		return null;
+	}
+}

--- a/apps/course-api/tsconfig.json
+++ b/apps/course-api/tsconfig.json
@@ -9,6 +9,7 @@
 			"@models/*": ["src/models/*"],
 			"@routes/*": ["src/routes/*"],
 			"@utils/*": ["src/utils/*"],
+			"@middlewares/*": ["src/middlewares/*"],
 			"@root/*": ["./*"]
 		},
 		"esModuleInterop": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1680,11 +1680,6 @@ packages:
     dependencies:
       undici-types: 5.26.5
 
-  /@types/node@20.10.6:
-    resolution: {integrity: sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==}
-    dependencies:
-      undici-types: 5.26.5
-
   /@types/node@20.5.2:
     resolution: {integrity: sha512-5j/lXt7unfPOUlrKC34HIaedONleyLtwkKggiD/0uuMfT8gg2EOpg0dz4lCD15Ga7muC+1WzJZAjIB9simWd6Q==}
     dev: true
@@ -7680,50 +7675,8 @@ packages:
     peerDependencies:
       postcss: ^8.3.3
     dependencies:
-    dev: true
       postcss: 8.4.33
     dev: true
-
-  /supabase@1.127.4:
-    resolution: {integrity: sha512-9vxMsRkG8Qqju+gjTL++G/DaUcMyVr9YAT3jeRkNKIzbVVd0QiHUp2NHXXlqs6EByJVZzpMYJf4h55ml/H7gpg==}
-    engines: {npm: '>=8'}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      bin-links: 4.0.3
-      https-proxy-agent: 7.0.2
-      node-fetch: 3.3.2
-      tar: 6.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /superagent@8.1.2:
-    resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
-    engines: {node: '>=6.4.0 <13 || >=14'}
-    dependencies:
-      component-emitter: 1.3.1
-      cookiejar: 2.1.4
-      debug: 4.3.4(supports-color@5.5.0)
-      fast-safe-stringify: 2.1.1
-      form-data: 4.0.0
-      formidable: 2.1.2
-      methods: 1.1.2
-      mime: 2.6.0
-      qs: 6.11.0
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /supertest@6.3.3:
-    resolution: {integrity: sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==}
-    engines: {node: '>=6.4.0'}
-    dependencies:
-      methods: 1.1.2
-      superagent: 8.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   /supabase@1.127.4:
     resolution: {integrity: sha512-9vxMsRkG8Qqju+gjTL++G/DaUcMyVr9YAT3jeRkNKIzbVVd0QiHUp2NHXXlqs6EByJVZzpMYJf4h55ml/H7gpg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       morgan:
         specifier: ^1.10.0
         version: 1.10.0
+      redis:
+        specifier: ^4.6.12
+        version: 4.6.12
     devDependencies:
       '@types/cors':
         specifier: ^2.8.17
@@ -1379,6 +1382,55 @@ packages:
     dependencies:
       '@prisma/debug': 5.7.1
 
+  /@redis/bloom@1.2.0(@redis/client@1.5.13):
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+    dependencies:
+      '@redis/client': 1.5.13
+    dev: false
+
+  /@redis/client@1.5.13:
+    resolution: {integrity: sha512-epkUM9D0Sdmt93/8Ozk43PNjLi36RZzG+d/T1Gdu5AI8jvghonTeLYV69WVWdilvFo+PYxbP0TZ0saMvr6nscQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+    dev: false
+
+  /@redis/graph@1.1.1(@redis/client@1.5.13):
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+    dependencies:
+      '@redis/client': 1.5.13
+    dev: false
+
+  /@redis/json@1.0.6(@redis/client@1.5.13):
+    resolution: {integrity: sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+    dependencies:
+      '@redis/client': 1.5.13
+    dev: false
+
+  /@redis/search@1.1.6(@redis/client@1.5.13):
+    resolution: {integrity: sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+    dependencies:
+      '@redis/client': 1.5.13
+    dev: false
+
+  /@redis/time-series@1.0.5(@redis/client@1.5.13):
+    resolution: {integrity: sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+    dependencies:
+      '@redis/client': 1.5.13
+    dev: false
+
   /@rushstack/eslint-patch@1.3.3:
     resolution: {integrity: sha512-0xd7qez0AQ+MbHatZTlI1gu5vkG8r7MYRUJAHPAHJBmGLs16zpkrpAVLvjQKQOqaXPDUBwOiJzNc00znHSCVBw==}
     dev: true
@@ -1625,6 +1677,11 @@ packages:
 
   /@types/node@20.11.2:
     resolution: {integrity: sha512-cZShBaVa+UO1LjWWBPmWRR4+/eY/JR/UIEcDlVsw3okjWEu+rB7/mH6X3B/L+qJVHDLjk9QW/y2upp9wp1yDXA==}
+    dependencies:
+      undici-types: 5.26.5
+
+  /@types/node@20.10.6:
+    resolution: {integrity: sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==}
     dependencies:
       undici-types: 5.26.5
 
@@ -2728,6 +2785,11 @@ packages:
   /clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
     engines: {node: '>=6'}
+    dev: false
+
+  /cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
     dev: false
 
   /cmd-shim@6.0.2:
@@ -4176,6 +4238,11 @@ packages:
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: true
+
+  /generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
+    dev: false
 
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -6991,6 +7058,17 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /redis@4.6.12:
+    resolution: {integrity: sha512-41Xuuko6P4uH4VPe5nE3BqXHB7a9lkFL0J29AlxKaIfD6eWO8VO/5PDF9ad2oS+mswMsfFxaM5DlE3tnXT+P8Q==}
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.5.13)
+      '@redis/client': 1.5.13
+      '@redis/graph': 1.1.1(@redis/client@1.5.13)
+      '@redis/json': 1.0.6(@redis/client@1.5.13)
+      '@redis/search': 1.1.6(@redis/client@1.5.13)
+      '@redis/time-series': 1.0.5(@redis/client@1.5.13)
+    dev: false
+
   /reflect.getprototypeof@1.0.3:
     resolution: {integrity: sha512-TTAOZpkJ2YLxl7mVHWrNo3iDMEkYlva/kgFcXndqMgbo/AZUmmavEkdXV+hXtE4P8xdyEKRzalaFqZVuwIk/Nw==}
     engines: {node: '>= 0.4'}
@@ -7602,8 +7680,50 @@ packages:
     peerDependencies:
       postcss: ^8.3.3
     dependencies:
+    dev: true
       postcss: 8.4.33
     dev: true
+
+  /supabase@1.127.4:
+    resolution: {integrity: sha512-9vxMsRkG8Qqju+gjTL++G/DaUcMyVr9YAT3jeRkNKIzbVVd0QiHUp2NHXXlqs6EByJVZzpMYJf4h55ml/H7gpg==}
+    engines: {npm: '>=8'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      bin-links: 4.0.3
+      https-proxy-agent: 7.0.2
+      node-fetch: 3.3.2
+      tar: 6.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /superagent@8.1.2:
+    resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
+    engines: {node: '>=6.4.0 <13 || >=14'}
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.3.4(supports-color@5.5.0)
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.0
+      formidable: 2.1.2
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.11.0
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /supertest@6.3.3:
+    resolution: {integrity: sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==}
+    engines: {node: '>=6.4.0'}
+    dependencies:
+      methods: 1.1.2
+      superagent: 8.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   /supabase@1.127.4:
     resolution: {integrity: sha512-9vxMsRkG8Qqju+gjTL++G/DaUcMyVr9YAT3jeRkNKIzbVVd0QiHUp2NHXXlqs6EByJVZzpMYJf4h55ml/H7gpg==}
@@ -8548,7 +8668,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
 
   /yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}


### PR DESCRIPTION
Apparently GitHub doesn't allow you to change the target branch after a PR has been created.. so...


Create a middleware that attempts to get cached data using URL path as key,

if data is found, simply return it
if not, retrieve data from the source and cache it (expires after 1 week)

ref: https://github.com/stamford-syntax-club/course-compose/pull/28