### PR TITLE
feat: api endpoint for editing reviews (both update and fix rejects)

### DIFF
--- a/apps/reviews-api/review/data/repository/helper.go
+++ b/apps/reviews-api/review/data/repository/helper.go
@@ -125,6 +125,18 @@ func hasExistingReview(ctx context.Context, prisma *db.PrismaClient, courseID in
 	return nil
 }
 
+func isReviewOwner(ctx context.Context, prisma *db.PrismaClient, submittedID, courseID int, userID string) error {
+	myReviewCh := make(chan *db.ReviewModel)
+	go getMyReview(ctx, prisma, userID, courseID, 1, myReviewCh)
+
+	result := <-myReviewCh
+	if result == nil || result.ID != submittedID {
+		return fiber.NewError(http.StatusBadRequest, "user is not the owner of this review")
+	}
+
+	return nil
+}
+
 func getUser(ctx context.Context, client *db.PrismaClient, userID string) (*db.ProfileModel, error) {
 	user, err := client.Profile.FindFirst(
 		db.Profile.ID.Equals(userID),

--- a/apps/reviews-api/review/data/repository/helper.go
+++ b/apps/reviews-api/review/data/repository/helper.go
@@ -131,7 +131,7 @@ func isReviewOwner(ctx context.Context, prisma *db.PrismaClient, submittedID, co
 
 	result := <-myReviewCh
 	if result == nil || result.ID != submittedID {
-		return fiber.NewError(http.StatusBadRequest, "user is not the owner of this review")
+		return fiber.NewError(http.StatusBadRequest, "User is not the owner of this review")
 	}
 
 	return nil

--- a/apps/reviews-api/review/data/repository/helper.go
+++ b/apps/reviews-api/review/data/repository/helper.go
@@ -127,9 +127,12 @@ func hasExistingReview(ctx context.Context, prisma *db.PrismaClient, courseID in
 
 func isReviewOwner(ctx context.Context, prisma *db.PrismaClient, submittedID, courseID int, userID string) error {
 	myReviewCh := make(chan *db.ReviewModel)
+
+	// get review's written user from that course
 	go getMyReview(ctx, prisma, userID, courseID, 1, myReviewCh)
 
 	result := <-myReviewCh
+	// check if user's review and the review user wants to edit has the same ID
 	if result == nil || result.ID != submittedID {
 		return fiber.NewError(http.StatusBadRequest, "User is not the owner of this review")
 	}

--- a/apps/reviews-api/review/data/repository/review_repo_impl.go
+++ b/apps/reviews-api/review/data/repository/review_repo_impl.go
@@ -102,9 +102,20 @@ func (r *reviewRepositoryImpl) EditReview(ctx context.Context, review *review_db
 		return nil, err
 	}
 
-    // TODO: update the review
+	result, err := r.reviewDB.Review.FindUnique(
+		review_db.Review.ID.Equals(review.ID),
+	).Update(
+		review_db.Review.AcademicYear.SetIfPresent(&review.AcademicYear),
+		review_db.Review.Description.SetIfPresent(&review.Description),
+		review_db.Review.Rating.SetIfPresent(&review.Rating),
+		review_db.Review.Status.Set("PENDING"), // edited review must be evaluated again
+	).Exec(ctx)
+	if err != nil {
+		log.Println("exec updating review: ", err)
+		return nil, fiber.ErrInternalServerError
+	}
 
-	return nil, nil
+	return result, nil
 }
 
 func (r *reviewRepositoryImpl) UpdateReviewStatus(ctx context.Context, reviewDecision *dto.ReviewDecisionDTO) (*review_db.ReviewModel, error) {

--- a/apps/reviews-api/review/data/repository/review_repo_impl.go
+++ b/apps/reviews-api/review/data/repository/review_repo_impl.go
@@ -88,6 +88,25 @@ func (r *reviewRepositoryImpl) SubmitReview(ctx context.Context, review *review_
 	return result, nil
 }
 
+func (r *reviewRepositoryImpl) EditReview(ctx context.Context, review *review_db.ReviewModel, courseCode, userID string) (*review_db.ReviewModel, error) {
+	courseID, err := getCourseID(ctx, r.reviewDB, courseCode)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := getUser(ctx, r.reviewDB, userID); err != nil {
+		return nil, err
+	}
+
+	if err := isReviewOwner(ctx, r.reviewDB, review.ID, courseID, userID); err != nil {
+		return nil, err
+	}
+
+    // TODO: update the review
+
+	return nil, nil
+}
+
 func (r *reviewRepositoryImpl) UpdateReviewStatus(ctx context.Context, reviewDecision *dto.ReviewDecisionDTO) (*review_db.ReviewModel, error) {
 	updatedReview, err := r.reviewDB.Review.FindUnique(
 		review_db.Review.ID.Equals(reviewDecision.ID),

--- a/apps/reviews-api/review/data/repository/review_repo_impl_integration_test.go
+++ b/apps/reviews-api/review/data/repository/review_repo_impl_integration_test.go
@@ -145,6 +145,96 @@ func TestGetCourseReview(t *testing.T) {
 	})
 }
 
+func TestEditReview(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	client := setupTestDB(t)
+	t.Cleanup(
+		func() {
+			cancel()
+			if err := client.Prisma.Disconnect(); err != nil {
+				t.Fatalf("Prisma Disconnect: %v", err)
+			}
+		})
+
+	repo := NewReviewRepositoryImpl(client)
+
+	const (
+		validCourseCode   = "MATH201"
+		invalidCourseCode = "CHINATHAI1234"
+		ownerID           = "2d1f3c4e-5a6b-7c8d-9e0f-1a2b3c4d5e6f"
+		nonOwnerID        = "6c7b1dd2-aa9d-4f5e-8a98-2c7c2895a95e"
+	)
+
+	/*
+		        Context: this is the review we are editing
+				{
+		            id: 2
+					academicYear: 2022,
+					description:  "The material was challenging but interesting.",
+					rating:       4,
+					votes:        8,
+					status:       "APPROVED",
+					courseId:     2,
+					userId:       "2d1f3c4e-5a6b-7c8d-9e0f-1a2b3c4d5e6f",
+				},
+	*/
+	newReview := &db.ReviewModel{
+		InnerReview: db.InnerReview{
+			ID:           2,
+			AcademicYear: 2023,
+			Description:  "Some edited data",
+			Rating:       2,
+		},
+	}
+
+	t.Run("update review as given in the model and set status back to pending for re-evaluation", func(t *testing.T) {
+		editedReview, err := repo.EditReview(ctx, newReview, validCourseCode, ownerID)
+
+		assert.NoError(t, err)
+		assert.Equal(t, newReview.AcademicYear, editedReview.AcademicYear)
+		assert.Equal(t, newReview.Description, editedReview.Description)
+		assert.Equal(t, newReview.Rating, editedReview.Rating)
+		assert.Equal(t, "PENDING", editedReview.Status)
+	})
+
+	errTest := []struct {
+		name       string
+		courseCode string
+		userId     string
+		errMsg     string
+	}{
+		{
+			name:       "return err if user is not owner of the review",
+			courseCode: validCourseCode,
+			userId:     nonOwnerID,
+			errMsg:     "User is not the owner of this review",
+		},
+		{
+			name:       "return err if course does not exist",
+			courseCode: invalidCourseCode,
+			userId:     ownerID,
+			errMsg:     "Course does not exist",
+		},
+		{
+			name:       "return err if user does not exist",
+			courseCode: validCourseCode,
+			userId:     "9c82c3b5-5b87-4c9b-832d-60d0966d4f7f",
+			errMsg:     "User does not exist",
+		},
+	}
+
+	for _, et := range errTest {
+		t.Run(et.name, func(t *testing.T) {
+			editedReview, err := repo.EditReview(ctx, newReview, et.courseCode, et.userId)
+
+			assert.Error(t, err)
+			assert.Equal(t, et.errMsg, err.Error())
+			assert.Nil(t, editedReview)
+		})
+
+	}
+}
+
 func TestSubmitReview(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	client := setupTestDB(t)
@@ -248,96 +338,6 @@ func TestSubmitReview(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
-}
-
-func TestEditReview(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	client := setupTestDB(t)
-	t.Cleanup(
-		func() {
-			cancel()
-			if err := client.Prisma.Disconnect(); err != nil {
-				t.Fatalf("Prisma Disconnect: %v", err)
-			}
-		})
-
-	repo := NewReviewRepositoryImpl(client)
-
-	const (
-		validCourseCode   = "MATH201"
-		invalidCourseCode = "CHINATHAI1234"
-		ownerID           = "2d1f3c4e-5a6b-7c8d-9e0f-1a2b3c4d5e6f"
-		nonOwnerID        = "6c7b1dd2-aa9d-4f5e-8a98-2c7c2895a95e"
-	)
-
-	/*
-		        Context: this is the review we are editing
-				{
-		            id: 2
-					academicYear: 2022,
-					description:  "The material was challenging but interesting.",
-					rating:       4,
-					votes:        8,
-					status:       "APPROVED",
-					courseId:     2,
-					userId:       "2d1f3c4e-5a6b-7c8d-9e0f-1a2b3c4d5e6f",
-				},
-	*/
-	newReview := &db.ReviewModel{
-		InnerReview: db.InnerReview{
-			ID:           2,
-			AcademicYear: 2023,
-			Description:  "Some edited data",
-			Rating:       2,
-		},
-	}
-
-	t.Run("update review as given in the model and set status back to pending for re-evaluation", func(t *testing.T) {
-		editedReview, err := repo.EditReview(ctx, newReview, validCourseCode, ownerID)
-
-		assert.NoError(t, err)
-		assert.Equal(t, newReview.AcademicYear, editedReview.AcademicYear)
-		assert.Equal(t, newReview.Description, editedReview.Description)
-		assert.Equal(t, newReview.Rating, editedReview.Rating)
-		assert.Equal(t, "PENDING", editedReview.Status)
-	})
-
-	errTest := []struct {
-		name       string
-		courseCode string
-		userId     string
-		errMsg     string
-	}{
-		{
-			name:       "return err if user is not owner of the review",
-			courseCode: validCourseCode,
-			userId:     nonOwnerID,
-			errMsg:     "User is not the owner of this review",
-		},
-		{
-			name:       "return err if course does not exist",
-			courseCode: invalidCourseCode,
-			userId:     ownerID,
-			errMsg:     "Course does not exist",
-		},
-		{
-			name:       "return err if user does not exist",
-			courseCode: validCourseCode,
-			userId:     "9c82c3b5-5b87-4c9b-832d-60d0966d4f7f",
-			errMsg:     "User does not exist",
-		},
-	}
-
-	for _, et := range errTest {
-		t.Run(et.name, func(t *testing.T) {
-			editedReview, err := repo.EditReview(ctx, newReview, et.courseCode, et.userId)
-
-			assert.Error(t, err)
-			assert.Equal(t, et.errMsg, err.Error())
-			assert.Nil(t, editedReview)
-		})
-
-	}
 }
 
 func seedReviewData(client *db.PrismaClient) {

--- a/apps/reviews-api/review/data/repository/review_repo_impl_integration_test.go
+++ b/apps/reviews-api/review/data/repository/review_repo_impl_integration_test.go
@@ -250,6 +250,96 @@ func TestSubmitReview(t *testing.T) {
 
 }
 
+func TestEditReview(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	client := setupTestDB(t)
+	t.Cleanup(
+		func() {
+			cancel()
+			if err := client.Prisma.Disconnect(); err != nil {
+				t.Fatalf("Prisma Disconnect: %v", err)
+			}
+		})
+
+	repo := NewReviewRepositoryImpl(client)
+
+	const (
+		validCourseCode   = "MATH201"
+		invalidCourseCode = "CHINATHAI1234"
+		ownerID           = "2d1f3c4e-5a6b-7c8d-9e0f-1a2b3c4d5e6f"
+		nonOwnerID        = "6c7b1dd2-aa9d-4f5e-8a98-2c7c2895a95e"
+	)
+
+	/*
+		        Context: this is the review we are editing
+				{
+		            id: 2
+					academicYear: 2022,
+					description:  "The material was challenging but interesting.",
+					rating:       4,
+					votes:        8,
+					status:       "APPROVED",
+					courseId:     2,
+					userId:       "2d1f3c4e-5a6b-7c8d-9e0f-1a2b3c4d5e6f",
+				},
+	*/
+	newReview := &db.ReviewModel{
+		InnerReview: db.InnerReview{
+			ID:           2,
+			AcademicYear: 2023,
+			Description:  "Some edited data",
+			Rating:       2,
+		},
+	}
+
+	t.Run("update review as given in the model and set status back to pending for re-evaluation", func(t *testing.T) {
+		editedReview, err := repo.EditReview(ctx, newReview, validCourseCode, ownerID)
+
+		assert.NoError(t, err)
+		assert.Equal(t, newReview.AcademicYear, editedReview.AcademicYear)
+		assert.Equal(t, newReview.Description, editedReview.Description)
+		assert.Equal(t, newReview.Rating, editedReview.Rating)
+		assert.Equal(t, "PENDING", editedReview.Status)
+	})
+
+	errTest := []struct {
+		name       string
+		courseCode string
+		userId     string
+		errMsg     string
+	}{
+		{
+			name:       "return err if user is not owner of the review",
+			courseCode: validCourseCode,
+			userId:     nonOwnerID,
+			errMsg:     "User is not the owner of this review",
+		},
+		{
+			name:       "return err if course does not exist",
+			courseCode: invalidCourseCode,
+			userId:     ownerID,
+			errMsg:     "Course does not exist",
+		},
+		{
+			name:       "return err if user does not exist",
+			courseCode: validCourseCode,
+			userId:     "9c82c3b5-5b87-4c9b-832d-60d0966d4f7f",
+			errMsg:     "User does not exist",
+		},
+	}
+
+	for _, et := range errTest {
+		t.Run(et.name, func(t *testing.T) {
+			editedReview, err := repo.EditReview(ctx, newReview, et.courseCode, et.userId)
+
+			assert.Error(t, err)
+			assert.Equal(t, et.errMsg, err.Error())
+			assert.Nil(t, editedReview)
+		})
+
+	}
+}
+
 func seedReviewData(client *db.PrismaClient) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*3)
 	defer cancelFunc()

--- a/apps/reviews-api/review/domain/controller/review_controller.go
+++ b/apps/reviews-api/review/domain/controller/review_controller.go
@@ -78,11 +78,29 @@ func (rc *ReviewController) SubmitReview(c *fiber.Ctx) error {
 
 func (rc *ReviewController) EditReview(c *fiber.Ctx) error {
 	review := db.ReviewModel{}
-	if err := c.BodyParser(&review); err != nil || review.Description == "" || review.AcademicYear == 0 {
+	// require review id for validating ownership
+	if err := c.BodyParser(&review); err != nil || review.ID == 0 || review.Description == "" || review.AcademicYear == 0 {
 		return fiber.NewError(http.StatusBadRequest, "Invalid request body")
 	}
 
-    return c.Status(http.StatusOK).JSON("edit review!")
+	courseCode := c.Params("courseCode")
+	if courseCode == "" {
+		return fiber.NewError(http.StatusBadRequest, "Invalid course code")
+	}
+
+	userID := utils.GetUserID(c)
+	if userID == "" {
+		return fiber.NewError(http.StatusBadRequest, "Invalid user ID")
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelFunc()
+	_, err := rc.reviewRepo.EditReview(ctx, &review, courseCode, userID)
+	if err != nil {
+		return err
+	}
+
+	return c.Status(http.StatusOK).JSON("edit review!")
 }
 
 func (rc *ReviewController) UpdateReviewStatus(c *fiber.Ctx) error {

--- a/apps/reviews-api/review/domain/controller/review_controller.go
+++ b/apps/reviews-api/review/domain/controller/review_controller.go
@@ -95,12 +95,12 @@ func (rc *ReviewController) EditReview(c *fiber.Ctx) error {
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFunc()
-	_, err := rc.reviewRepo.EditReview(ctx, &review, courseCode, userID)
+	result, err := rc.reviewRepo.EditReview(ctx, &review, courseCode, userID)
 	if err != nil {
 		return err
 	}
 
-	return c.Status(http.StatusOK).JSON("edit review!")
+	return c.Status(http.StatusOK).JSON(result)
 }
 
 func (rc *ReviewController) UpdateReviewStatus(c *fiber.Ctx) error {

--- a/apps/reviews-api/review/domain/controller/review_controller.go
+++ b/apps/reviews-api/review/domain/controller/review_controller.go
@@ -76,6 +76,15 @@ func (rc *ReviewController) SubmitReview(c *fiber.Ctx) error {
 	return c.Status(http.StatusCreated).JSON(result)
 }
 
+func (rc *ReviewController) EditReview(c *fiber.Ctx) error {
+	review := db.ReviewModel{}
+	if err := c.BodyParser(&review); err != nil || review.Description == "" || review.AcademicYear == 0 {
+		return fiber.NewError(http.StatusBadRequest, "Invalid request body")
+	}
+
+    return c.Status(http.StatusOK).JSON("edit review!")
+}
+
 func (rc *ReviewController) UpdateReviewStatus(c *fiber.Ctx) error {
 	reviewDecision := &dto.ReviewDecisionDTO{}
 	if err := c.BodyParser(reviewDecision); err != nil || reviewDecision.ID == 0 || reviewDecision.Status == "" {

--- a/apps/reviews-api/review/domain/repository/review_repo.go
+++ b/apps/reviews-api/review/domain/repository/review_repo.go
@@ -11,5 +11,6 @@ import (
 type ReviewRepository interface {
 	GetCourseReviews(context.Context, string, string, *utils.PageInformation) ([]db.ReviewModel, int, error)
 	SubmitReview(context.Context, *db.ReviewModel, string, string) (*db.ReviewModel, error)
+	EditReview(context.Context, *db.ReviewModel, string, string) (*db.ReviewModel, error)
 	UpdateReviewStatus(context.Context, *dto.ReviewDecisionDTO) (*db.ReviewModel, error)
 }

--- a/apps/reviews-api/review/presentation/router/review_router.go
+++ b/apps/reviews-api/review/presentation/router/review_router.go
@@ -19,6 +19,7 @@ type ReviewRouter struct {
 func (r *ReviewRouter) RegisterRoutes() {
 	r.commonRouter.Get("/courses/:courseCode/reviews", middleware.JWTAuth(), r.rc.GetReviews)
 	r.commonRouter.Post("/courses/:courseCode/reviews", middleware.JWTAuth(), r.rc.SubmitReview)
+	r.commonRouter.Put("/courses/:courseCode/reviews/edit", middleware.JWTAuth(), r.rc.EditReview)
 	r.commonRouter.Put("/admin/reviews", middleware.AdminAuth(), r.rc.UpdateReviewStatus)
 }
 


### PR DESCRIPTION
endpoint: `PUT /api/courses/:courseCode/reviews/edit`

request body:
```json
{
    "id": 5,
    "academic_year": 2023,
    "description": "Nvm, I hate it woops!",
    "rating": 2
}
```
requires JWT Auth