### PR TITLE
pipeline: production image build

### DIFF
--- a/.github/workflows/deploy-ghcr.yaml
+++ b/.github/workflows/deploy-ghcr.yaml
@@ -16,6 +16,7 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }} 
 
     strategy:
       matrix:
@@ -38,6 +39,19 @@ jobs:
             echo "Dockerfile exists"
             echo "DOCKERFILE_EXISTS=true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set frontend env
+        if: ${{ matrix.packages.name }} == 'web'
+        run: |
+            echo "Setting env for frontend";
+            echo "NEXT_PUBLIC_SUPABASE_URL=\"${{ secrets.SUPABASE_URL }}\"" >> apps/${{ matrix.packages.name }}/.env
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=\"${{ secrets.SUPABASE_ANON_KEY }}\"" >> apps/${{ matrix.packages.name }}/.env
+            echo "NEXT_PUBLIC_APP_ENV=\"${{ inputs.environment }}\"" >> apps/${{ matrix.packages.name }}/.env
+            echo "NEXT_PUBLIC_BACKEND_URL=\"https://gateway.stamford.dev/api\"" >> apps/${{ matrix.packages.name }}/.env
+            echo "Testing environment: ${{ vars.TEST }}"
+            cat apps/${{ matrix.packages.name }}/.env
+
+        # NOT SURE IF .env is loaded inside during build or not... 
 
       - name: Login ghcr.io
         uses: docker/login-action@v2.1.0

--- a/.github/workflows/deploy-ghcr.yaml
+++ b/.github/workflows/deploy-ghcr.yaml
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Set frontend env
-        if: ${{ matrix.packages.name }} == 'web'
+        if: ${{ contains(fromJson('["web"]'), matrix.packages.name) && steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true' }}
         run: |
             echo "Setting env for frontend";
             echo "NEXT_PUBLIC_SUPABASE_URL=\"${{ vars.SUPABASE_URL }}\"" >> apps/${{ matrix.packages.name }}/.env

--- a/.github/workflows/deploy-ghcr.yaml
+++ b/.github/workflows/deploy-ghcr.yaml
@@ -47,9 +47,7 @@ jobs:
             echo "NEXT_PUBLIC_SUPABASE_URL=\"${{ vars.SUPABASE_URL }}\"" >> apps/${{ matrix.packages.name }}/.env
             echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=\"${{ vars.SUPABASE_ANON_KEY }}\"" >> apps/${{ matrix.packages.name }}/.env
             echo "NEXT_PUBLIC_APP_ENV=\"${{ inputs.environment }}\"" >> apps/${{ matrix.packages.name }}/.env
-            echo "NEXT_PUBLIC_BACKEND_URL=\"https://gateway.stamford.dev/api\"" >> apps/${{ matrix.packages.name }}/.env
-            echo "Testing environment: ${{ vars.TEST }}"
-            cat apps/${{ matrix.packages.name }}/.env
+            echo "NEXT_PUBLIC_BACKEND_URL=\"${{ vars.BACKEND_URL }}\"" >> apps/${{ matrix.packages.name }}/.env
 
         # NOT SURE IF .env is loaded inside during build or not... 
 

--- a/.github/workflows/deploy-ghcr.yaml
+++ b/.github/workflows/deploy-ghcr.yaml
@@ -44,8 +44,8 @@ jobs:
         if: ${{ matrix.packages.name }} == 'web'
         run: |
             echo "Setting env for frontend";
-            echo "NEXT_PUBLIC_SUPABASE_URL=\"${{ secrets.SUPABASE_URL }}\"" >> apps/${{ matrix.packages.name }}/.env
-            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=\"${{ secrets.SUPABASE_ANON_KEY }}\"" >> apps/${{ matrix.packages.name }}/.env
+            echo "NEXT_PUBLIC_SUPABASE_URL=\"${{ vars.SUPABASE_URL }}\"" >> apps/${{ matrix.packages.name }}/.env
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=\"${{ vars.SUPABASE_ANON_KEY }}\"" >> apps/${{ matrix.packages.name }}/.env
             echo "NEXT_PUBLIC_APP_ENV=\"${{ inputs.environment }}\"" >> apps/${{ matrix.packages.name }}/.env
             echo "NEXT_PUBLIC_BACKEND_URL=\"https://gateway.stamford.dev/api\"" >> apps/${{ matrix.packages.name }}/.env
             echo "Testing environment: ${{ vars.TEST }}"

--- a/.github/workflows/deploy-ghcr.yaml
+++ b/.github/workflows/deploy-ghcr.yaml
@@ -49,8 +49,6 @@ jobs:
             echo "NEXT_PUBLIC_APP_ENV=\"${{ inputs.environment }}\"" >> apps/${{ matrix.packages.name }}/.env
             echo "NEXT_PUBLIC_BACKEND_URL=\"${{ vars.BACKEND_URL }}\"" >> apps/${{ matrix.packages.name }}/.env
 
-        # NOT SURE IF .env is loaded inside during build or not... 
-
       - name: Login ghcr.io
         uses: docker/login-action@v2.1.0
         with:

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - khing/ci/prod
 
 permissions:
     actions: read
@@ -49,7 +50,7 @@ jobs:
             - name: Generate package deployment information
               id: generate-deployment
               run: |
-                  packages_deployment=$(echo '${{ env.PACKAGES }}' | jq -c 'map({name: ., imageTag:"ghcr.io/stamford-syntax-club/course-compose:\(.)-${{ env.GITHUB_SHA }}"})')
+                  packages_deployment=$(echo '${{ env.PACKAGES }}' | jq -c 'map({name: ., imageTag:"ghcr.io/stamford-syntax-club/course-compose/\(.):${{ env.GITHUB_SHA }}"})')
                   echo "PACKAGES_DEPLOYMENT=$packages_deployment" >> $GITHUB_OUTPUT
                   echo "PACKAGES_DEPLOYMENT=$packages_deployment"
 

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-            - khing/ci/prod
 
 permissions:
     actions: read

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -14,8 +14,13 @@ on:
 jobs:
     pre-release:
         runs-on: ubuntu-latest
+
+        outputs:
+            packages_deployment: ${{ steps.generate-deployment.outputs.PACKAGES_DEPLOYMENT }}
+
         steps:
             - name: generate production deployment manifest
+              id: generate-deployment
               run: |
                   packages_deployment=$(echo '["${{ inputs.deploy-service }}"]' | jq -c 'map({name: ., imageTag:"ghcr.io/stamford-syntax-club/course-compose/\(.):prod-${{ inputs.deploy-tag }}"})')
                   echo "PACKAGES_DEPLOYMENT=$packages_deployment" >> $GITHUB_OUTPUT

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -1,0 +1,30 @@
+name: Production Release CI/CD
+on:
+    workflow_dispatch:
+        inputs:
+            deploy-service:
+                description: "Name of the service to deploy"
+                required: true
+                type: string
+            deploy-tag:
+                description: "Tag for deployment"
+                required: true
+                type: string
+
+jobs:
+    pre-release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: generate production deployment manifest
+              run: |
+                  packages_deployment=$(echo '["${{ inputs.deploy-service }}"]' | jq -c 'map({name: ., imageTag:"ghcr.io/stamford-syntax-club/course-compose/\(.):prod-${{ inputs.deploy-tag }}"})')
+                  echo "PACKAGES_DEPLOYMENT=$packages_deployment" >> $GITHUB_OUTPUT
+                  echo "PACKAGES_DEPLOYMENT=$packages_deployment"
+
+    deploy-ghcr:
+        needs: pre-release
+        if: ${{ needs.pre-release.outputs.packages_deployment != '[]' }}
+        uses: ./.github/workflows/deploy-ghcr.yaml
+        with:
+            packages_deployment: ${{ needs.pre-release.outputs.packages_deployment }}
+            environment: production

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -15,7 +15,7 @@ import { useState } from "react";
 
 const COURSE_LIST = [
 	{
-		courseName: "Basic Mathematics",
+		courseName: "Basic Mathematics XD",
 		courseCode: "MAT101",
 		coursePrerequisites: [],
 		courseRating: 4.0,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -15,7 +15,7 @@ import { useState } from "react";
 
 const COURSE_LIST = [
 	{
-		courseName: "Basic Mathematics XD",
+		courseName: "Basic Mathematics",
 		courseCode: "MAT101",
 		coursePrerequisites: [],
 		courseRating: 4.0,


### PR DESCRIPTION
Manual trigger workflow for production
- Need to enter service to deploy and the image tag

Add extra step for building frontend service (next.js being next.js)
- The value of SUPABASE_URL, SUPABASE_ANON_KEY, and BACKEND_URL can be configured in [Github Environment](https://github.com/stamford-syntax-club/course-compose/settings/environments)

Change format for Image tag
- Beta image: `ghcr.io/stamford-syntax-club/course-compose/<service_name>:<image_tag>`
- Production image: `ghcr.io/stamford-syntax-club/course-compose/<service_name>:prod-<image_tag>`


*Notes: GitOps step hasn't been implemented yet*