### PR TITLE
fix: course search & filtering feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,8 +39,8 @@ jobs:
             - name: Unit test
               run: pnpm run unit
 
-            - name: Integration test
-              run: pnpm run integration
-
             - name: Test
               run: pnpm run test
+
+            - name: Integration test
+              run: pnpm run integration

--- a/apps/api-gateway/routers/helper.go
+++ b/apps/api-gateway/routers/helper.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -62,7 +63,8 @@ func appendQueryParams(queries map[string]string, endpoint *string) {
 	}
 
 	for key, value := range queries {
-		*endpoint += fmt.Sprintf("%s=%s&", key, value)
+		encodedValue := url.QueryEscape(value)
+		*endpoint += fmt.Sprintf("%s=%s&", key, encodedValue)
 	}
 }
 

--- a/apps/api-gateway/routers/routes_test.go
+++ b/apps/api-gateway/routers/routes_test.go
@@ -89,6 +89,13 @@ func TestAppendQueryParams(t *testing.T) {
 			},
 			expectedEndpoint: "http://test-endpoint.com?userId=9&hello=world&foo=bar&",
 		},
+		{
+			name: "should escape string so it can be safely passed on the URL",
+			queries: map[string]string{
+				"search": "Course Closed",
+			},
+			expectedEndpoint: "http://test-endpoint.com?search=Course+Closed&",
+		},
 	}
 
 	for _, test := range tests {

--- a/apps/course-api/package.json
+++ b/apps/course-api/package.json
@@ -56,6 +56,7 @@
     "@routes": "dist/src/routes",
     "@utils": "dist/src/utils",
     "@middlewares": "dist/src/middlewares",
+    "@services": "dist/src/services",
     "@root": "."
   }
 }

--- a/apps/course-api/src/controllers/courses.controller.ts
+++ b/apps/course-api/src/controllers/courses.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { paginate } from "@utils/pagination";
-import { getAllCourses, getCourseByCode } from "./get-courses";
+import { getAllCourses, getCourseByCode } from "@services/get-course.services";
 import { getRedisClient } from "@utils/redis_utils";
 
 const cacheTTL = 60 * 60 * 7; // cache will expire after 1 week
@@ -8,6 +8,8 @@ const cacheTTL = 60 * 60 * 7; // cache will expire after 1 week
 const handleGetAllCourses = async (req: Request, res: Response) => {
 	const pageSize = parseInt(req.query.pageSize as string) ? parseInt(req.query.pageSize as string) : 10;
 	const pageNumber = parseInt(req.query.pageNumber as string) ? parseInt(req.query.pageNumber as string) : 1;
+	let sortBy = (req.query.sortBy as "name" | "reviewCount") || "reviewCount";
+	let order = (req.query.order as "asc" | "desc") || "desc";
 	const search = (req.query.search as string) || "";
 
 	if (pageSize < 1 || pageNumber < 1) {
@@ -17,7 +19,7 @@ const handleGetAllCourses = async (req: Request, res: Response) => {
 	}
 
 	try {
-		const { courseResponse, count } = await getAllCourses(search, pageSize, pageNumber);
+		const { courseResponse, count } = await getAllCourses(sortBy, order, search, pageSize, pageNumber);
 		const data = paginate(courseResponse, pageSize, pageNumber, count);
 
 		// fire and forget

--- a/apps/course-api/src/services/get-course.services.ts
+++ b/apps/course-api/src/services/get-course.services.ts
@@ -24,7 +24,13 @@ const getCourseByCode = async (code: string) => {
 	}
 };
 
-const getAllCourses = async (search: string, pageSize: number, pageNumber: number) => {
+const getAllCourses = async (
+	sortBy: "name" | "reviewCount",
+	sortOrder: "asc" | "desc",
+	search: string,
+	pageSize: number,
+	pageNumber: number
+) => {
 	const query: Prisma.CourseFindManyArgs = {
 		where: {
 			OR: [
@@ -43,7 +49,6 @@ const getAllCourses = async (search: string, pageSize: number, pageNumber: numbe
 			]
 		}
 	};
-
 	const [courses, count] = await prismaClient.$transaction([
 		prismaClient.course.findMany({
 			...query,
@@ -58,7 +63,21 @@ const getAllCourses = async (search: string, pageSize: number, pageNumber: numbe
 						status: "APPROVED"
 					}
 				}
-			}
+			},
+			orderBy: (() => {
+				if (sortBy === "reviewCount") {
+					return {
+						reviews: {
+							_count: sortOrder
+						}
+					};
+				}
+				if (sortBy === "name") {
+					return {
+						full_name: sortOrder
+					};
+				}
+			})()
 		}),
 		prismaClient.course.count({ where: query.where })
 	]);

--- a/apps/course-api/tsconfig.json
+++ b/apps/course-api/tsconfig.json
@@ -10,6 +10,7 @@
 			"@routes/*": ["src/routes/*"],
 			"@utils/*": ["src/utils/*"],
 			"@middlewares/*": ["src/middlewares/*"],
+			"@services/*": ["src/services/*"],
 			"@root/*": ["./*"]
 		},
 		"esModuleInterop": true,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,6 +11,7 @@ import {
 	TextInput,
 	Container,
 	Slider,
+	Text,
 	Title,
 	Loader,
 	Select,
@@ -56,7 +57,7 @@ export default function HomePage(): JSX.Element {
 	}, [pageNumber, apiClient, debounceSearchValue, sortField, sortOrder]);
 
 	//handle the search result to always set at page 1
-	const handleSearchValueChange = (event: { target: { value: any } }) => {
+	const handleSearchValueChange = (event: { target: { value: any } }): void => {
 		const searchValue = event.target.value;
 		setCurrentSearch(searchValue);
 		setPageNumber(1);
@@ -216,47 +217,44 @@ export default function HomePage(): JSX.Element {
 
 				{/* Courses List Body */}
 				<Paper bg="dark.8" p="sm" withBorder className="h-full">
-					{courseList && courseList.data.length > 0 ? (
-						//course state with results
+					{isLoading ? (
+						<div className="flex w-full flex-col items-center gap-y-4">
+							<Loader color="blue" type="bars" />
+							<Text>Loading</Text>
+						</div>
+					) : null}
+					{!isLoading && courseList && courseList.data.length > 0 ? (
 						<div className="relative flex size-full flex-col">
-							{isLoading ? (
-								<Loader color="blue" type="bars" className="my-2 flex content-center self-center" />
-							) : null}
 							<div className="grid grid-cols-12 grid-rows-3 gap-x-2 gap-y-2">
-								{courseList
-									? courseList.data.map((course) => {
-											return (
-												<CourseCard
-													// Ensure that the key is unique, otherwise same keys will cause a lot of issues.
-													key={`CourseCard_${course.code}`}
-													full_name={course.full_name}
-													code={course.code}
-													prerequisites={course.prerequisites}
-													overall_ratings={course.overall_ratings}
-													reviews_count={course.reviews_count}
-												/>
-											);
-										})
-									: null}
+								{courseList.data.map((course) => (
+									<CourseCard
+										key={`CourseCard_${course.code}`}
+										full_name={course.full_name}
+										code={course.code}
+										prerequisites={course.prerequisites}
+										overall_ratings={course.overall_ratings}
+										reviews_count={course.reviews_count}
+									/>
+								))}
 							</div>
 							<div className="mt-6 flex items-center justify-center">
 								<Pagination
 									withEdges
-									total={courseList.totalPages ?? 1}
+									total={courseList.totalPages}
 									value={pageNumber}
 									onChange={setPageNumber}
 								/>
 							</div>
 						</div>
-					) : isLoading ? null : (
-						//Empty state of the course list
+					) : null}
+					{!isLoading && courseList && courseList.data.length === 0 ? (
 						<div className="p-sm flex h-full flex-col items-center justify-center text-center">
 							<IconMoodSad size={50} />
 							<Title order={2} textWrap="wrap" c="gray">
 								No course result found for your search!
 							</Title>
 						</div>
-					)}
+					) : null}
 				</Paper>
 			</Stack>
 		</Container>

--- a/apps/web/lib/api/api.ts
+++ b/apps/web/lib/api/api.ts
@@ -8,11 +8,9 @@ import {
 	ERR_USER_NOT_EXIST,
 	ERR_MISSING_TOKEN,
 	ERR_USER_NOT_OWNER,
-	COURSE_API_ENDPOINT,
-	BASE_API_ENDPOINT
+	COURSE_API_ENDPOINT
 } from "@utils/constants";
 import type { NotificationData } from "@mantine/notifications";
-import fetcher, { FetcherResult } from "@utils/fetcher";
 
 export default class CourseComposeAPIClient {
 	private courseEndpoint: string;
@@ -23,8 +21,15 @@ export default class CourseComposeAPIClient {
 		this.reviewEndpoint = `${this.courseEndpoint}/reviews`;
 	}
 
-	async fetchCourse(searchValue: string, pageNumber: number): Promise<PaginatedResponse<Course>> {
-		const data = await fetch(`${COURSE_API_ENDPOINT}?pageNumber=${pageNumber}&pageSize=9&search=${searchValue}`);
+	async fetchCourse(
+		sortBy: string,
+		sortOrder: string,
+		searchValue: string,
+		pageNumber: number
+	): Promise<PaginatedResponse<Course>> {
+		const data = await fetch(
+			`${COURSE_API_ENDPOINT}?pageNumber=${pageNumber}&pageSize=9&search=${searchValue}&sortBy=${sortBy}&order=${sortOrder}`
+		);
 
 		if (!data.ok) {
 			const err = (await data.json()) as ErrorResponse;


### PR DESCRIPTION
Filtering logic is moved to backend to better support pagination

Due to the current database design, courses can only be filtered through review counts and name. The issue to allow filter through ratings, minimum ratings, minimum counts is: https://github.com/stamford-syntax-club/course-compose/issues/65

Fix a bug where api gateway did not encode query parameters and cause the corresponding service to return Bad Request



