### PR TITLE
frontend: add sign in confirmation modal + reword show review limit alert

### DIFF
--- a/apps/web/app/courses/[courseCode]/page.tsx
+++ b/apps/web/app/courses/[courseCode]/page.tsx
@@ -148,8 +148,8 @@ export default function CourseReview({ params }: { params: { courseCode: string 
 			<Stack gap="sm">
 				{showReviewLimitAlert ? (
 					<Alert color="yellow" icon={<IconLock />}>
-						Explore up to 2 reviews per course. Share your thoughts by writing your first review to discover
-						more reviews and insights!
+						Explore up to 2 reviews per course. Unlock this by submitting your first review in any course
+						you have taken.
 					</Alert>
 				) : null}
 				{reviewsData?.data && reviewsData.data.length > 0

--- a/apps/web/app/courses/[courseCode]/page.tsx
+++ b/apps/web/app/courses/[courseCode]/page.tsx
@@ -94,11 +94,6 @@ export default function CourseReview({ params }: { params: { courseCode: string 
 				setReviewsData(reviews);
 			} catch (err) {
 				console.error(err);
-				notifications.show({
-					title: "Error!",
-					message: "Something went wrong, please try again later",
-					color: "red"
-				});
 			} finally {
 				setIsLoading(false);
 			}
@@ -148,7 +143,7 @@ export default function CourseReview({ params }: { params: { courseCode: string 
 			<Stack gap="sm">
 				{showReviewLimitAlert ? (
 					<Alert color="yellow" icon={<IconLock />}>
-						Explore up to 2 reviews per course. Unlock this by submitting your first review in any course
+						Explore up to 2 reviews per course. Unlock this by submitting your first review in any courses
 						you have taken.
 					</Alert>
 				) : null}

--- a/apps/web/components/core/application-navbar.tsx
+++ b/apps/web/components/core/application-navbar.tsx
@@ -3,8 +3,10 @@ import { AppShell, Button, Flex, NavLink, Stack } from "@mantine/core";
 import { useAuth } from "hooks/use-auth";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-
+import { useDisclosure } from "@mantine/hooks";
 import { IconBooks, IconHistory, IconHome } from "@tabler/icons-react";
+import SigninConfirmationModal from "@components/ui/signin-confirmation";
+
 export const navItems = [
 	{
 		label: "Home",
@@ -25,9 +27,9 @@ export const navItems = [
 ];
 
 export default function ApplicationNavbar({ opened, toggle }: { opened: boolean; toggle: () => void }): JSX.Element {
-	const { signIn, signOut, getSession } = useAuth();
-	const [working, setWorking] = useState(false);
+	const { signOut, working, getSession } = useAuth();
 	const [signedIn, setSignedIn] = useState(false);
+	const [openedSignInConfirmation, { open: openConfirmation, close: closeConfirmation }] = useDisclosure(false);
 
 	useEffect(() => {
 		getSession()
@@ -38,29 +40,6 @@ export default function ApplicationNavbar({ opened, toggle }: { opened: boolean;
 			})
 			.catch(console.error);
 	}, [getSession]);
-
-	// TODO: This is code duplicated with application-header.tsx, should be refactored into a hook
-	const handleSignInWithAzure = (): void => {
-		if (working) return;
-		setWorking(true);
-
-		signIn()
-			.catch(console.error)
-			.finally(() => {
-				setWorking(false);
-			});
-	};
-
-	const handleSignOut = (): void => {
-		if (working) return;
-		setWorking(true);
-
-		signOut()
-			.catch(console.error)
-			.finally(() => {
-				setWorking(false);
-			});
-	};
 
 	return (
 		<AppShell.Navbar p="md" hidden={!opened}>
@@ -83,19 +62,20 @@ export default function ApplicationNavbar({ opened, toggle }: { opened: boolean;
 
 				<Flex className="mt-auto">
 					{signedIn ? (
-						<Button color="red" className="w-full" onClick={handleSignOut}>
+						<Button color="red" className="w-full" onClick={signOut}>
 							Sign Out
 						</Button>
 					) : (
 						<Button
 							disabled={working}
 							variant="default"
-							onClick={handleSignInWithAzure}
+							onClick={openConfirmation}
 							className="w-full select-none text-lg font-bold uppercase"
 						>
 							Sign In
 						</Button>
 					)}
+					<SigninConfirmationModal opened={openedSignInConfirmation} close={closeConfirmation} />
 				</Flex>
 			</Stack>
 		</AppShell.Navbar>

--- a/apps/web/components/ui/signin-confirmation.tsx
+++ b/apps/web/components/ui/signin-confirmation.tsx
@@ -1,0 +1,38 @@
+import { Alert, Button, Divider, Flex, Group, Modal, Text, Title } from "@mantine/core";
+import { IconAlertCircle } from "@tabler/icons-react";
+import { useAuth } from "hooks/use-auth";
+
+export default function SigninConfirmationModal({ opened, close }: { opened: boolean; close: () => void }) {
+	const { signIn, working } = useAuth();
+
+	return (
+		<Modal
+			opened={opened}
+			onClose={close}
+			title={<Title order={3}>Signing in to Course Compose</Title>}
+			size="auto"
+		>
+			<Flex direction="column" gap="lg" align="center" maw={500}>
+				<Alert icon={<IconAlertCircle />}>
+					Please read the following to if you have any concerns regarding the use of your Stamford accounts
+				</Alert>
+
+				<Text ta="center">
+					By signing in, you will be redirected to the Microsoft login Page which <b>automatically</b>{" "}
+					retrieves your recent sessions. This process is solely to confirm your status as a Stamford student.
+				</Text>
+				<Text ta="center" fs="italic">
+					We, Stamford Syntax Club, <b>do not have</b> access to your credentials
+				</Text>
+				<Group>
+					<Button disabled={working} onClick={signIn}>
+						Sign In
+					</Button>
+					<Button variant="transparent" onClick={close}>
+						No, take me back
+					</Button>
+				</Group>
+			</Flex>
+		</Modal>
+	);
+}

--- a/apps/web/lib/api/api.ts
+++ b/apps/web/lib/api/api.ts
@@ -8,9 +8,10 @@ import {
 	ERR_USER_NOT_EXIST,
 	ERR_MISSING_TOKEN,
 	ERR_USER_NOT_OWNER,
-	COURSE_API_ENDPOINT
+	COURSE_API_ENDPOINT,
+	ERR_USER_NOT_STUDENT
 } from "@utils/constants";
-import type { NotificationData } from "@mantine/notifications";
+import { notifications, type NotificationData } from "@mantine/notifications";
 
 export default class CourseComposeAPIClient {
 	private courseEndpoint: string;
@@ -38,8 +39,7 @@ export default class CourseComposeAPIClient {
 
 		return data.json() as Promise<PaginatedResponse<Course>>;
 	}
-	
-	
+
 	async fetchCourseDetails(): Promise<Course> {
 		const data = await fetch(this.courseEndpoint);
 
@@ -60,6 +60,21 @@ export default class CourseComposeAPIClient {
 
 		if (!data.ok) {
 			const err = (await data.json()) as ErrorResponse;
+			if (err.message === ERR_USER_NOT_STUDENT) {
+				notifications.show({
+					title: err.message,
+					message: "Please sign out as guests to continue using the site",
+					color: "red",
+					autoClose: 5000
+				});
+			} else {
+				notifications.show({
+					title: "Something is wrong on our end",
+					message: "We could not retrieve reviews for this course at the moment, please try again later",
+					color: "red",
+					autoClose: 5000
+				});
+			}
 			throw new Error(err.message);
 		}
 
@@ -106,6 +121,13 @@ export default class CourseComposeAPIClient {
 				return {
 					title: errMsg,
 					message: "You can either edit or delete your existing review",
+					color: "red",
+					autoClose: 5000
+				};
+			case ERR_USER_NOT_STUDENT:
+				return {
+					title: errMsg,
+					message: "Please sign out as guests to continue using the site",
 					color: "red",
 					autoClose: 5000
 				};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"private": true,
 	"scripts": {
 		"dev": "next dev --turbo",

--- a/apps/web/utils/constants.ts
+++ b/apps/web/utils/constants.ts
@@ -3,6 +3,7 @@ export const ERR_EXPIRED_TOKEN = "token has invalid claims: token is expired";
 export const ERR_REVIEW_EXIST = "You have already written a review for this course";
 export const ERR_USER_NOT_EXIST = "User does not exist";
 export const ERR_USER_NOT_OWNER = "User is not the owner of this review";
+export const ERR_USER_NOT_STUDENT = "Only Stamford students can access this service";
 export const ERR_INTERNAL_SERVER = "Internal Server Error";
 
 if (!process.env.NEXT_PUBLIC_BACKEND_URL) {


### PR DESCRIPTION
- Notify users to sign out if their account is not stamford student (This is a very safe temporary solution - the review page is very critical and changes should be carefully tested in beta server before deployment which we can't do it yet....)
- Force refresh when sign out to clear all the sessions and prevent from being able to do things you shouldn't (e.g. see their "My reviews" after signing out)
- This modal will appear when clicking on the sign in button in both header and navbar


![image](https://github.com/stamford-syntax-club/course-compose/assets/92321280/755060f0-2253-41c3-95e4-4aeb021a75d5)
