### PR TITLE
frontend: integrate term and section when submitting and editing review

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -32,9 +32,8 @@ jobs:
                   node-version: 18
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v2.2.2
+              uses: pnpm/action-setup@v4
               with:
-                  version: 8
                   run_install: false
 
             - name: Install turbo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,8 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v2.2.2
+              uses: pnpm/action-setup@v4
               with:
-                  version: 8
                   run_install: false
 
             - name: Install turbo

--- a/apps/web/app/courses/[courseCode]/page.tsx
+++ b/apps/web/app/courses/[courseCode]/page.tsx
@@ -167,10 +167,12 @@ export default function CourseReview({ params }: CourseReviewProps): JSX.Element
 								<MyReviewCard
 									key={`my_review_card_${review.id}`}
 									review={review}
-									onEditReview={(id, academicYear, description, rating) =>
+									onEditReview={(id, section, term, academicYear, description, rating) =>
 										apiClient
 											.submitEditedReview(
 												id,
+												section,
+												term,
 												academicYear,
 												description,
 												rating,
@@ -218,9 +220,16 @@ export default function CourseReview({ params }: CourseReviewProps): JSX.Element
 			</Title>
 			<WriteReviewForm
 				courseCode={params.courseCode}
-				onSubmit={(academicYear, description, rating) =>
+				onSubmit={(section, term, academicYear, description, rating) =>
 					apiClient
-						.submitNewReview(academicYear, description, rating, sessionData?.access_token || "")
+						.submitNewReview(
+							section,
+							term,
+							academicYear,
+							description,
+							rating,
+							sessionData?.access_token || ""
+						)
 						.then((result) => {
 							handleSubmitResponse(result);
 							return result.color === "green";

--- a/apps/web/components/core/application-navbar.tsx
+++ b/apps/web/components/core/application-navbar.tsx
@@ -19,15 +19,15 @@ export const navItems = [
 		icon: <IconHistory />
 	},
 	{
+		label: "Guidelines",
+		href: "/guidelines",
+		icon: <IconCheckbox />
+	},
+	{
 		label: "Resources",
 		href: "https://center.stamford.dev/resources",
 		newTab: true,
 		icon: <IconBooks />
-	},
-	{
-		label: "Guidelines",
-		href: "/guidelines",
-		icon: <IconCheckbox />
 	}
 ];
 

--- a/apps/web/components/ui/review-card.tsx
+++ b/apps/web/components/ui/review-card.tsx
@@ -78,7 +78,9 @@ export function ReviewCard({ review }: ReviewCardProps): JSX.Element {
 				<Flex direction="column" justify="flex-start" ml="3" gap="4" w="100%">
 					<Rating size="md" value={review.rating} fractions={2} defaultValue={0} readOnly />
 					<Text fw={800} size="sm">
-						Academic Year: {review.academicYear}
+						Academic Year:{" "}
+						{review.term ? `${review.term}/${review.academicYear}` : `${review.academicYear}`}
+						{review.section && ` - Section: ${review.section}`}
 					</Text>
 					<Spoiler maxHeight={75} showLabel="Show more" hideLabel="Hide">
 						<TypographyStylesProvider mt="md">
@@ -138,7 +140,9 @@ export function MyReviewCard({ review, onEditReview, onDeleteReview }: ReviewCar
 
 						<Rating size="md" value={review.rating} fractions={2} defaultValue={0} readOnly />
 						<Text fw={800} size="md">
-							Academic Year: {review.academicYear}
+							Academic Year:{" "}
+							{review.term ? `${review.term}/${review.academicYear}` : `${review.academicYear}`}
+							{review.section && ` - Section: ${review.section}`}
 						</Text>
 						<Spoiler maxHeight={75} showLabel="Show more" hideLabel="Hide">
 							<TypographyStylesProvider mt="sm">

--- a/apps/web/components/ui/review-card.tsx
+++ b/apps/web/components/ui/review-card.tsx
@@ -20,7 +20,14 @@ import WriteReviewForm from "./write-review-form";
 
 interface ReviewCardProps {
 	review: Review;
-	onEditReview?: (id: number, academicYear: string, description: string, rating: number) => void;
+	onEditReview?: (
+		id: number,
+		section: string,
+		term: string,
+		academicYear: string,
+		description: string,
+		rating: number
+	) => void;
 	onDeleteReview?: (id: number) => void;
 }
 
@@ -169,9 +176,9 @@ export function MyReviewCard({ review, onEditReview, onDeleteReview }: ReviewCar
 			>
 				{/* Modal content */}
 				<WriteReviewForm
-					onSubmit={(academicYear, description, rating) => {
+					onSubmit={(section, term, academicYear, description, rating) => {
 						// when user submit their edited review
-						if (onEditReview) onEditReview(review.id, academicYear, description, rating);
+						if (onEditReview) onEditReview(review.id, section, term, academicYear, description, rating);
 						closeEdit();
 						return Promise.resolve(true);
 					}}

--- a/apps/web/components/ui/write-review-form.tsx
+++ b/apps/web/components/ui/write-review-form.tsx
@@ -11,11 +11,10 @@ import type { Review } from "types/reviews";
 import Link from "next/link";
 
 const academicYearOptions = [
-	{ value: "2020", label: "2020" },
-	{ value: "2021", label: "2021" },
-	{ value: "2022", label: "2022" },
+	{ value: "2024", label: "2024" },
 	{ value: "2023", label: "2023" },
-	{ value: "2024", label: "2024" }
+	{ value: "2022", label: "2022" },
+	{ value: "2021", label: "2021" }
 ];
 
 interface WriteReviewFormProps {
@@ -33,7 +32,7 @@ const reviewGuidelines = [
 	{
 		text: (
 			<div>
-				Kindly refrain from mentioning names and write your reviews with respect.{" "}
+				Constructive criticism is encouraged.{" "}
 				<span className="underline">
 					<Link href="/guidelines" target="_blank">
 						Click here to learn more
@@ -57,6 +56,8 @@ export default function WriteReviewForm({ courseCode, onSubmit, previousReview }
 	const reviewKeys = useMemo(() => reviewFormKeys(courseCode || ""), [courseCode]);
 	const [academicYear, setAcademicYear] = useState<string | null>(previousReview?.academicYear || null);
 	const [rating, setRating] = useState(previousReview?.rating || 0);
+	const [term, setTerm] = useState<string | null>(null);
+	const [section, setSection] = useState<string | null>(null);
 
 	const markdownEditor = useEditor({
 		extensions: [
@@ -139,13 +140,30 @@ export default function WriteReviewForm({ courseCode, onSubmit, previousReview }
 			))}
 
 			<Paper w="100%" h="100%">
-				<Flex direction="row" gap="sm" my="sm">
+				<Flex align="end" wrap="wrap" direction="row" gap="xs" my="sm">
 					<Select
+						className="w-[100px]"
+						data={["1", "2", "3", "4", "5"]}
+						value={section}
+						label="Section"
+						onChange={setSection}
+						placeholder="Section"
+					/>
+					<Select
+						className="w-[100px]"
+						data={["1", "2", "3"]}
+						value={term}
+						label="Term"
+						onChange={setTerm}
+						placeholder="Term"
+					/>
+					<Select
+						className="w-[100px]"
 						data={academicYearOptions}
 						value={academicYear}
-						defaultSearchValue={academicYear || undefined}
+						label="Year"
 						onChange={setAcademicYear}
-						placeholder="Academic year"
+						placeholder="year"
 					/>
 					<Rating size="lg" defaultValue={0} fractions={2} value={rating} onChange={setRating} />
 				</Flex>

--- a/apps/web/components/ui/write-review-form.tsx
+++ b/apps/web/components/ui/write-review-form.tsx
@@ -10,16 +10,15 @@ import { MarkdownEditor } from "@components/ui/markdown-editor";
 import type { Review } from "types/reviews";
 import Link from "next/link";
 
-const academicYearOptions = [
-	{ value: "2024", label: "2024" },
-	{ value: "2023", label: "2023" },
-	{ value: "2022", label: "2022" },
-	{ value: "2021", label: "2021" }
-];
-
 interface WriteReviewFormProps {
 	courseCode?: string;
-	onSubmit: (academicYear: string, description: string, rating: number) => Promise<boolean>;
+	onSubmit: (
+		section: string,
+		term: string,
+		academicYear: string,
+		description: string,
+		rating: number
+	) => Promise<boolean>;
 	previousReview?: Review;
 }
 
@@ -139,7 +138,7 @@ export default function WriteReviewForm({ courseCode, onSubmit, previousReview }
 			});
 			return;
 		}
-		onSubmit(academicYear!!, currentDescription, rating).then((success) => {
+		onSubmit(section!!, term!!, academicYear!!, currentDescription, rating).then((success) => {
 			if (success) {
 				resetForm();
 				localStorage.removeItem(reviewKeys.academicYearKey);
@@ -182,11 +181,11 @@ export default function WriteReviewForm({ courseCode, onSubmit, previousReview }
 					/>
 					<Select
 						className="w-[100px]"
-						data={academicYearOptions}
+						data={["2021", "2022", "2023", "2024", "2025"]}
 						value={academicYear}
 						label="Year"
 						onChange={setAcademicYear}
-						placeholder="year"
+						placeholder="Year"
 					/>
 					<Rating size="lg" defaultValue={0} fractions={2} value={rating} onChange={setRating} />
 				</Flex>

--- a/apps/web/lib/api/api.ts
+++ b/apps/web/lib/api/api.ts
@@ -82,6 +82,8 @@ export default class CourseComposeAPIClient {
 	}
 
 	async submitNewReview(
+		section: string,
+		term: string,
 		academicYear: string,
 		description: string,
 		rating: number,
@@ -90,6 +92,8 @@ export default class CourseComposeAPIClient {
 		const data = await fetch(this.reviewEndpoint, {
 			method: "POST",
 			body: JSON.stringify({
+				section: parseInt(section),
+				term: parseInt(term),
 				academic_year: parseInt(academicYear),
 				description,
 				rating
@@ -143,6 +147,8 @@ export default class CourseComposeAPIClient {
 
 	async submitEditedReview(
 		id: number,
+		section: string,
+		term: string,
 		academicYear: string,
 		description: string,
 		rating: number,
@@ -152,6 +158,8 @@ export default class CourseComposeAPIClient {
 			method: "PUT",
 			body: JSON.stringify({
 				id,
+				section: parseInt(section),
+				term: parseInt(term),
 				academic_year: parseInt(academicYear),
 				description,
 				rating

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"private": true,
 	"scripts": {
 		"dev": "next dev --turbo",

--- a/apps/web/types/reviews.ts
+++ b/apps/web/types/reviews.ts
@@ -3,6 +3,8 @@ export interface Review {
 	academicYear: string;
 	description: string;
 	isOwner: boolean;
+	term: number;
+	section: number;
 	rating: number;
 	status: string;
 	rejectedReason: string;


### PR DESCRIPTION
- update request body upon api calls
- store section and term in local storage
- also fix the failing pipeline (not our fault btw!) to resolve this issue https://github.com/pnpm/pnpm/issues/6424
- display term and section on review card

![image](https://github.com/stamford-syntax-club/course-compose/assets/92321280/17f27ad5-e63e-4b95-a7ef-804864f388fa)
![image](https://github.com/stamford-syntax-club/course-compose/assets/92321280/ca8355c5-00d6-4905-b864-edceefad0038)
![image](https://github.com/stamford-syntax-club/course-compose/assets/92321280/ef1c4996-665a-43a5-ac92-40512fe3439d)
![image](https://github.com/stamford-syntax-club/course-compose/assets/92321280/9a3cf12b-78c7-465f-b398-be298669aedf)
